### PR TITLE
Remove direct inventory editing

### DIFF
--- a/Admin-Portal/src/components/inventory/InventoryDialog.tsx
+++ b/Admin-Portal/src/components/inventory/InventoryDialog.tsx
@@ -49,7 +49,7 @@ const AddInventoryDialog: React.FC<InventoryDialogProps> = ({
           label="Item Name"
           type="text"
           variant="standard"
-          defaultValue={editRow?.itemName}
+          defaultValue={editRow?.name}
         />
         <FormControl fullWidth margin="dense">
           <InputLabel id="inventory-category">Inventory Category</InputLabel>
@@ -86,7 +86,7 @@ const AddInventoryDialog: React.FC<InventoryDialogProps> = ({
           label="New Stock"
           type="number"
           variant="standard"
-          defaultValue={editRow?.newStock}
+          defaultValue={editRow?.quantityNew}
         />
         <TextField
           autoFocus
@@ -97,7 +97,7 @@ const AddInventoryDialog: React.FC<InventoryDialogProps> = ({
           label="New Value"
           type="number"
           variant="standard"
-          defaultValue={editRow?.newValue}
+          defaultValue={editRow?.valueNew}
         />
       </div>
       <div>
@@ -110,7 +110,7 @@ const AddInventoryDialog: React.FC<InventoryDialogProps> = ({
           label="Used Stock"
           type="number"
           variant="standard"
-          defaultValue={editRow?.usedStock}
+          defaultValue={editRow?.quantityUsed}
         />
         <TextField
           autoFocus
@@ -121,7 +121,7 @@ const AddInventoryDialog: React.FC<InventoryDialogProps> = ({
           label="Used Value"
           type="number"
           variant="standard"
-          defaultValue={editRow?.usedValue}
+          defaultValue={editRow?.valueUsed}
         />
       </div>
     </Box>

--- a/Admin-Portal/src/lib/contexts.tsx
+++ b/Admin-Portal/src/lib/contexts.tsx
@@ -49,7 +49,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       localStorage.setItem("emailForSignIn", email);
       console.log("Login link sent!");
     } catch (error) {
-      console.error("Error sending login link:", error.message);
+      console.error("Error sending login link:", (error as Error).message);
     }
   };
 
@@ -62,7 +62,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         await signInWithEmailLink(auth, email, window.location.href);
         window.localStorage.removeItem("emailForSignIn");
       } catch (error) {
-        console.error("Error signing in with email link:", error.message);
+        console.error(
+          "Error signing in with email link:",
+          (error as Error).message
+        );
       }
     }
   };

--- a/Admin-Portal/src/pages/InventoryPage.tsx
+++ b/Admin-Portal/src/pages/InventoryPage.tsx
@@ -43,10 +43,10 @@ const InventoryPage: React.FC = () => {
   const [sortModel, setSortModel] = useState<GridSortModel | undefined>();
   const [totalNumber, setTotalNumber] = useState(0);
   const [openAddInventory, setOpenAddInventory] = useState(false);
-  // const [openEditInventory, setOpenEditInventory] = useState(false);
+  const [openEditInventory, setOpenEditInventory] = useState(false);
   const [openDeleteInventory, setOpenDeleteInventory] = useState(false);
   const [deleteRow, setDeleteRow] = useState<inventoryRow | undefined>();
-  // const [editRow, setEditRow] = useState<inventoryRow | undefined>();
+  const [editRow, setEditRow] = useState<inventoryRow | undefined>();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean | null>(null);
   const queryClient = useQueryClient();
@@ -59,15 +59,15 @@ const InventoryPage: React.FC = () => {
     setOpenAddInventory(false);
   };
 
-  // const handleOpenEditInventory = (row: inventoryRow) => {
-  //   setEditRow(row);
-  //   setOpenEditInventory(true);
-  // };
+  const handleOpenEditInventory = (row: inventoryRow) => {
+    setEditRow(row);
+    setOpenEditInventory(true);
+  };
 
-  // const handleCloseEditInventory = () => {
-  //   setEditRow(undefined);
-  //   setOpenEditInventory(false);
-  // };
+  const handleCloseEditInventory = () => {
+    setEditRow(undefined);
+    setOpenEditInventory(false);
+  };
   const handleOpenDeleteInventory = (row: inventoryRow) => {
     setDeleteRow(row);
     setOpenDeleteInventory(true);
@@ -131,20 +131,20 @@ const InventoryPage: React.FC = () => {
     },
   });
 
-  // const editMutation = useMutation({
-  //   mutationFn: (data: any) => editInventoryItem(data),
-  //   onSuccess: (result: Response) => {
-  //     queryClient.invalidateQueries({ queryKey: ["inventory"] });
-  //     if (result.status === 400 || result.status === 500) {
-  //       setError("Cannot edit inventory item");
-  //     } else {
-  //       setSuccess(true);
-  //     }
-  //   },
-  //   onError: (error: Error) => {
-  //     setError(error.message);
-  //   },
-  // });
+  const editMutation = useMutation({
+    mutationFn: (data: any) => editInventoryItem(data),
+    onSuccess: (result: Response) => {
+      queryClient.invalidateQueries({ queryKey: ["inventory"] });
+      if (result.status === 400 || result.status === 500) {
+        setError("Cannot edit inventory item");
+      } else {
+        setSuccess(true);
+      }
+    },
+    onError: (error: Error) => {
+      setError(error.message);
+    },
+  });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteInventoryItem(id, "token"),
@@ -183,23 +183,23 @@ const InventoryPage: React.FC = () => {
     handleCloseDeleteInventory();
   };
 
-  // const handleEditRow = (event: React.FormEvent<HTMLFormElement>) => {
-  //   if (!editRow) return;
-  //   event.preventDefault();
-  //   const formData = new FormData(event.currentTarget);
-  //   const formJson = Object.fromEntries((formData as any).entries());
-  //   const itemData = {
-  //     name: formJson.name,
-  //     category: formJson.category,
-  //     quantityNew: formJson.quantityNew,
-  //     valueNew: formJson.valueNew,
-  //     quantityUsed: formJson.quantityUsed,
-  //     valueUsed: formJson.valueUsed,
-  //   };
-  //   const editData = { data: itemData, id: editRow.id };
-  //   editMutation.mutate(editData);
-  //   handleCloseEditInventory();
-  // };
+  const handleEditRow = (event: React.FormEvent<HTMLFormElement>) => {
+    if (!editRow) return;
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const formJson = Object.fromEntries((formData as any).entries());
+    const itemData = {
+      name: formJson.name,
+      category: formJson.category,
+      quantityNew: formJson.quantityNew,
+      valueNew: formJson.valueNew,
+      quantityUsed: formJson.quantityUsed,
+      valueUsed: formJson.valueUsed,
+    };
+    const editData = { data: itemData, id: editRow.id };
+    editMutation.mutate(editData);
+    handleCloseEditInventory();
+  };
 
   if (inventoryQueryResponse.isLoading) return <div>Loading...</div>;
   if (inventoryQueryResponse.error)
@@ -244,7 +244,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      // editable: true,
+      editable: true,
     },
     {
       field: "valueNew",
@@ -253,7 +253,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      // editable: true,
+      editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -268,7 +268,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      // editable: true,
+      editable: true,
     },
     {
       field: "valueUsed",
@@ -277,7 +277,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      // editable: true,
+      editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -290,13 +290,13 @@ const InventoryPage: React.FC = () => {
       type: "actions",
       getActions: (params: GridRowParams) => {
         return [
-          // <GridActionsCellItem
-          //   icon={<img src={editIcon} />}
-          //   onClick={() => {
-          //     handleOpenEditInventory(params.row);
-          //   }}
-          //   label="Edit"
-          // />,
+          <GridActionsCellItem
+            icon={<img src={editIcon} />}
+            onClick={() => {
+              handleOpenEditInventory(params.row);
+            }}
+            label="Edit"
+          />,
           <GridActionsCellItem
             icon={<img src={deleteIcon} />}
             onClick={() => {
@@ -349,7 +349,14 @@ const InventoryPage: React.FC = () => {
       >
         <InventoryDialog categories={categoryOptions} />
       </FormDialog>
-
+      <FormDialog
+        title={"EDIT A INVENTORY ENTRY"}
+        handleClose={handleCloseEditInventory}
+        open={openEditInventory}
+        handleSubmit={handleEditRow}
+      >
+        <InventoryDialog categories={categoryOptions} editRow={editRow} />
+      </FormDialog>
       <DeleteAlertModal
         scenario={"Inventory Entry"}
         handleDelete={handleDeleteRow}
@@ -361,13 +368,3 @@ const InventoryPage: React.FC = () => {
 };
 
 export default InventoryPage;
-{
-  /* <FormDialog
-title={"EDIT A INVENTORY ENTRY"}
-handleClose={handleCloseEditInventory}
-open={openEditInventory}
-handleSubmit={handleEditRow}
->
-<InventoryDialog categories={categoryOptions} editRow={editRow} />
-</FormDialog> */
-}

--- a/Admin-Portal/src/pages/InventoryPage.tsx
+++ b/Admin-Portal/src/pages/InventoryPage.tsx
@@ -95,7 +95,7 @@ const InventoryPage: React.FC = () => {
         .then((data) => {
           setTotalNumber(data.totalNumber);
           if (data === undefined) {
-            throw new Error("No data: Internal Server Error");
+            setError("No data: Internal Server Error");
           }
           const renderInventories = data.inventory.map(
             (item: ResponseInventoryItem) => ({
@@ -225,7 +225,6 @@ const InventoryPage: React.FC = () => {
       flex: 3,
       align: "left",
       headerAlign: "left",
-      editable: true,
     },
     {
       field: "category",
@@ -235,7 +234,6 @@ const InventoryPage: React.FC = () => {
       valueOptions: categoryOptions,
       align: "left",
       headerAlign: "left",
-      editable: true,
     },
     {
       field: "quantityNew",
@@ -244,7 +242,6 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
     },
     {
       field: "valueNew",
@@ -253,7 +250,6 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -268,7 +264,6 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
     },
     {
       field: "valueUsed",
@@ -277,7 +272,6 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -321,7 +315,6 @@ const InventoryPage: React.FC = () => {
       </Button>
       <div className="grid-container">
         <DataGrid
-          editMode="row"
           rowHeight={40}
           sx={{ width: "100%", height: "68vh" }}
           rows={inventoryQueryResponse.data || []}

--- a/Admin-Portal/src/pages/InventoryPage.tsx
+++ b/Admin-Portal/src/pages/InventoryPage.tsx
@@ -43,10 +43,10 @@ const InventoryPage: React.FC = () => {
   const [sortModel, setSortModel] = useState<GridSortModel | undefined>();
   const [totalNumber, setTotalNumber] = useState(0);
   const [openAddInventory, setOpenAddInventory] = useState(false);
-  const [openEditInventory, setOpenEditInventory] = useState(false);
+  // const [openEditInventory, setOpenEditInventory] = useState(false);
   const [openDeleteInventory, setOpenDeleteInventory] = useState(false);
   const [deleteRow, setDeleteRow] = useState<inventoryRow | undefined>();
-  const [editRow, setEditRow] = useState<inventoryRow | undefined>();
+  // const [editRow, setEditRow] = useState<inventoryRow | undefined>();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean | null>(null);
   const queryClient = useQueryClient();
@@ -59,15 +59,15 @@ const InventoryPage: React.FC = () => {
     setOpenAddInventory(false);
   };
 
-  const handleOpenEditInventory = (row: inventoryRow) => {
-    setEditRow(row);
-    setOpenEditInventory(true);
-  };
+  // const handleOpenEditInventory = (row: inventoryRow) => {
+  //   setEditRow(row);
+  //   setOpenEditInventory(true);
+  // };
 
-  const handleCloseEditInventory = () => {
-    setEditRow(undefined);
-    setOpenEditInventory(false);
-  };
+  // const handleCloseEditInventory = () => {
+  //   setEditRow(undefined);
+  //   setOpenEditInventory(false);
+  // };
   const handleOpenDeleteInventory = (row: inventoryRow) => {
     setDeleteRow(row);
     setOpenDeleteInventory(true);
@@ -131,20 +131,20 @@ const InventoryPage: React.FC = () => {
     },
   });
 
-  const editMutation = useMutation({
-    mutationFn: (data: any) => editInventoryItem(data),
-    onSuccess: (result: Response) => {
-      queryClient.invalidateQueries({ queryKey: ["inventory"] });
-      if (result.status === 400 || result.status === 500) {
-        setError("Cannot edit inventory item");
-      } else {
-        setSuccess(true);
-      }
-    },
-    onError: (error: Error) => {
-      setError(error.message);
-    },
-  });
+  // const editMutation = useMutation({
+  //   mutationFn: (data: any) => editInventoryItem(data),
+  //   onSuccess: (result: Response) => {
+  //     queryClient.invalidateQueries({ queryKey: ["inventory"] });
+  //     if (result.status === 400 || result.status === 500) {
+  //       setError("Cannot edit inventory item");
+  //     } else {
+  //       setSuccess(true);
+  //     }
+  //   },
+  //   onError: (error: Error) => {
+  //     setError(error.message);
+  //   },
+  // });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteInventoryItem(id, "token"),
@@ -183,23 +183,23 @@ const InventoryPage: React.FC = () => {
     handleCloseDeleteInventory();
   };
 
-  const handleEditRow = (event: React.FormEvent<HTMLFormElement>) => {
-    if (!editRow) return;
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const formJson = Object.fromEntries((formData as any).entries());
-    const itemData = {
-      name: formJson.name,
-      category: formJson.category,
-      quantityNew: formJson.quantityNew,
-      valueNew: formJson.valueNew,
-      quantityUsed: formJson.quantityUsed,
-      valueUsed: formJson.valueUsed,
-    };
-    const editData = { data: itemData, id: editRow.id };
-    editMutation.mutate(editData);
-    handleCloseEditInventory();
-  };
+  // const handleEditRow = (event: React.FormEvent<HTMLFormElement>) => {
+  //   if (!editRow) return;
+  //   event.preventDefault();
+  //   const formData = new FormData(event.currentTarget);
+  //   const formJson = Object.fromEntries((formData as any).entries());
+  //   const itemData = {
+  //     name: formJson.name,
+  //     category: formJson.category,
+  //     quantityNew: formJson.quantityNew,
+  //     valueNew: formJson.valueNew,
+  //     quantityUsed: formJson.quantityUsed,
+  //     valueUsed: formJson.valueUsed,
+  //   };
+  //   const editData = { data: itemData, id: editRow.id };
+  //   editMutation.mutate(editData);
+  //   handleCloseEditInventory();
+  // };
 
   if (inventoryQueryResponse.isLoading) return <div>Loading...</div>;
   if (inventoryQueryResponse.error)
@@ -244,7 +244,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
+      // editable: true,
     },
     {
       field: "valueNew",
@@ -253,7 +253,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
+      // editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -268,7 +268,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
+      // editable: true,
     },
     {
       field: "valueUsed",
@@ -277,7 +277,7 @@ const InventoryPage: React.FC = () => {
       type: "number",
       align: "left",
       headerAlign: "left",
-      editable: true,
+      // editable: true,
       valueFormatter: (params: GridValueFormatterParams<number>) => {
         if (params.value == null) {
           return "$0";
@@ -290,13 +290,13 @@ const InventoryPage: React.FC = () => {
       type: "actions",
       getActions: (params: GridRowParams) => {
         return [
-          <GridActionsCellItem
-            icon={<img src={editIcon} />}
-            onClick={() => {
-              handleOpenEditInventory(params.row);
-            }}
-            label="Edit"
-          />,
+          // <GridActionsCellItem
+          //   icon={<img src={editIcon} />}
+          //   onClick={() => {
+          //     handleOpenEditInventory(params.row);
+          //   }}
+          //   label="Edit"
+          // />,
           <GridActionsCellItem
             icon={<img src={deleteIcon} />}
             onClick={() => {
@@ -349,14 +349,7 @@ const InventoryPage: React.FC = () => {
       >
         <InventoryDialog categories={categoryOptions} />
       </FormDialog>
-      <FormDialog
-        title={"EDIT A INVENTORY ENTRY"}
-        handleClose={handleCloseEditInventory}
-        open={openEditInventory}
-        handleSubmit={handleEditRow}
-      >
-        <InventoryDialog categories={categoryOptions} editRow={editRow} />
-      </FormDialog>
+
       <DeleteAlertModal
         scenario={"Inventory Entry"}
         handleDelete={handleDeleteRow}
@@ -368,3 +361,13 @@ const InventoryPage: React.FC = () => {
 };
 
 export default InventoryPage;
+{
+  /* <FormDialog
+title={"EDIT A INVENTORY ENTRY"}
+handleClose={handleCloseEditInventory}
+open={openEditInventory}
+handleSubmit={handleEditRow}
+>
+<InventoryDialog categories={categoryOptions} editRow={editRow} />
+</FormDialog> */
+}

--- a/Admin-Portal/src/types/inventory.tsx
+++ b/Admin-Portal/src/types/inventory.tsx
@@ -24,10 +24,10 @@ export interface AddInventoryItemType {
 
 export interface inventoryRow {
   id: number;
-  itemName: String;
+  name: String;
   category: String;
-  newStock: number;
-  newValue: number;
-  usedStock: number;
-  usedValue: number;
+  quantityNew: number;
+  valueNew: number;
+  quantityUsed: number;
+  valueUsed: number;
 }


### PR DESCRIPTION
Removed edit button, editability on inventory quantities and value. Inventory name and category remains editable.
![image](https://github.com/ChangePlusPlusVandy/MotherToMother/assets/56850524/43fbd048-1d87-4de0-9adf-0cbfad4e9b75)
